### PR TITLE
Split sendmsg feature into setup and usage

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,6 +10,7 @@ mon_icinga_mail_domain: foo.example.com
 mon_icinga_mail_user: root
 mon_icinga_director_password: False
 mon_use_sendmsg: False
+mon_setup_sendmsg: "{{ mon_use_sendmsg }}"
 mon_sendmsg_config: []
 
 # Things you will probably want to overrride

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,12 +29,12 @@
     apt: name={{ item }} state=present update_cache=yes cache_valid_time=1800
     with_items:
       - sendmsg
-    when: mon_use_sendmsg
+    when: mon_setup_sendmsg
     tags: icconf
 
   - name: Create sendmsg config
     become: True
-    when: mon_use_sendmsg
+    when: mon_setup_sendmsg
     copy: content="{{ mon_sendmsg_config|to_nice_yaml }}" dest=/etc/sendmsg.yml owner=root group=root mode=0644
     tags: icconf
 


### PR DESCRIPTION
Separate sendmsg usage in code files from setting up the package and
config.

This is needed in situations where sendmsg is provided by other roles
which would collide with the setup procedure in this role.

The goal is achieved by introducing a new sendmsg flag for setting up as
opposed to using it. The change is backward compatible by using the same
default for the new flag mon_setup_sendmsg as the existing flag mon_use_sendmsg