### PR TITLE
Prometheus: Fix command-line flags

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,7 +12,6 @@ mon_icinga_director_password: False
 mon_use_sendmsg: False
 mon_setup_sendmsg: "{{ mon_use_sendmsg }}"
 mon_sendmsg_config: []
-mon_prometheus_memory_chunks: 1048576
 
 # Things you will probably want to overrride
 mon_prometheus_job_relabling:

--- a/templates/prometheus.j2
+++ b/templates/prometheus.j2
@@ -1,5 +1,5 @@
 # Set the command-line arguments to pass to the server.
-ARGS="-web.listen-address \"127.0.0.1:9090\" -storage.local.memory-chunks {{ mon_prometheus_memory_chunks }}"
+ARGS="--web.listen-address \"127.0.0.1:9090\""
 
 # Prometheus supports the following options:
 


### PR DESCRIPTION
* Remove unsupported "-storage.local.memory-chunks". Prometheus2 reworked its storage structure
* Use double dashes for long options