### PR TITLE
Rename systemd-check

### DIFF
--- a/templates/icinga2/services.conf.j2
+++ b/templates/icinga2/services.conf.j2
@@ -308,8 +308,8 @@ apply Service "systemd" for (systemd => config in host.vars.systemd)  {
   check_command = "custom-systemd"
 
   vars += config
-  vars.datgroup = "systemd2"
-  vars.datitem = systemd2
+  vars.datgroup = "systemd"
+  vars.datitem = systemd
 }
 
 apply ScheduledDowntime "downtime " for (downtime => config in host.vars.downtime) to Service {

--- a/templates/icinga2/services.conf.j2
+++ b/templates/icinga2/services.conf.j2
@@ -305,7 +305,7 @@ apply Service "ups load" {
 
 apply Service "systemd" for (systemd => config in host.vars.systemd)  {
   import "normal-service"
-  check_command = "systemd2"
+  check_command = "custom-systemd"
 
   vars += config
   vars.datgroup = "systemd2"

--- a/templates/icinga2/services.conf.j2
+++ b/templates/icinga2/services.conf.j2
@@ -303,7 +303,7 @@ apply Service "ups load" {
   vars.datgroup = "ups"
 }
 
-apply Service "systemd2" for (systemd2 => config in host.vars.systemd)  {
+apply Service "systemd" for (systemd => config in host.vars.systemd)  {
   import "normal-service"
   check_command = "systemd2"
 
@@ -327,4 +327,3 @@ apply Service "ldap" for (ldap => config in host.vars.ldap) {
   vars.datgroup = "ldap"
   vars.datitem = ldap
 }
-

--- a/templates/icinga2/services.conf.j2
+++ b/templates/icinga2/services.conf.j2
@@ -303,13 +303,13 @@ apply Service "ups load" {
   vars.datgroup = "ups"
 }
 
-apply Service "systemd" for (systemd => config in host.vars.systemd)  {
+apply Service "systemd2" for (systemd2 => config in host.vars.systemd)  {
   import "normal-service"
-  check_command = "systemd"
+  check_command = "systemd2"
 
   vars += config
-  vars.datgroup = "systemd"
-  vars.datitem = systemd
+  vars.datgroup = "systemd2"
+  vars.datitem = systemd2
 }
 
 apply ScheduledDowntime "downtime " for (downtime => config in host.vars.downtime) to Service {


### PR DESCRIPTION
The new version of icinga2 adds an own CheckCommand with the name "systemd", making icinga not start if the custom systemd-check of this role is used (since the CheckCommand "systemd" then is defined twice).
This PR renames the custom systemd-check so that the role can be used with the same ansible-configuration as before.